### PR TITLE
feat: Implementar seguimiento de eventos de e-commerce para GA4

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,13 @@
 <!doctype html>
 <html lang="es">
   <head>
+      <!-- Google Tag Manager -->
+      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-MCRS25V7');</script>
+      <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -33,6 +40,10 @@
     <meta name="google-site-verification" content="INyo-gSGmg2UHauAMTWbiv6KaNXTd8qbOI5lTavW08A" />
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MCRS25V7"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <noscript><img height="1" width="1" style="display:none"
     src="https://www.facebook.com/tr?id=1111607510484951&ev=PageView&noscript=1"
     /></noscript>

--- a/src/components/FloatingButtons.jsx
+++ b/src/components/FloatingButtons.jsx
@@ -10,6 +10,12 @@ function FloatingButtons() {
     if (window.fbq) {
       window.fbq('track', 'Contact');
     }
+
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      event: 'generate_lead',
+      contact_method: 'whatsapp'
+    });
   };
 
   return (

--- a/src/pages/CartPage.jsx
+++ b/src/pages/CartPage.jsx
@@ -21,6 +21,20 @@ const CartPage = () => {
       window.fbq('track', 'InitiateCheckout', checkoutData);
     }
     // --- FIN: CÓDIGO AÑADIDO PARA EL PÍXEL DE META ---
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      event: 'begin_checkout',
+      ecommerce: {
+        currency: 'UYU',
+        value: cartTotal,
+        items: cart.map(item => ({
+          item_id: item.productId,
+          item_name: item.productName,
+          price: item.unitPrice,
+          quantity: item.quantity
+        }))
+      }
+    });
     
     navigate('/checkout');
   };

--- a/src/pages/ContactoPage.jsx
+++ b/src/pages/ContactoPage.jsx
@@ -19,6 +19,12 @@ function ContactoPage() {
         window.fbq('track', 'Contact');
       }
       
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        event: 'generate_lead',
+        contact_method: 'formulario'
+      });
+
     } else {
       document.title = 'Contacto - Tapicería Ivar';
     }

--- a/src/pages/OrderSucessPage.jsx
+++ b/src/pages/OrderSucessPage.jsx
@@ -74,6 +74,23 @@ const OrderSuccessPage = () => {
         const parts = value.split(`; ${name}=`);
         if (parts.length === 2) return parts.pop().split(';').shift();
     };
+
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      event: 'purchase',
+      ecommerce: {
+        transaction_id: `pedido_${order.numero_pedido}`,
+        value: order.total_pedido,
+        currency: 'UYU',
+        items: order.pedido_items.map(item => ({
+          item_id: item.productos.sku,
+          item_name: item.productos.nombre,
+          price: item.precio_unitario,
+          quantity: item.cantidad
+        }))
+      }
+    });
+
     const enviarConversionAMeta = async () => {
       try {
         const userData = {

--- a/src/pages/ProductDetailPage.jsx
+++ b/src/pages/ProductDetailPage.jsx
@@ -56,6 +56,20 @@ function ProductDetailPage() {
         currency: 'UYU'
       };
       window.fbq('track', 'ViewContent', productData);
+
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        event: 'view_item',
+        ecommerce: {
+          currency: 'UYU',
+          value: product.precio_base,
+          items: [{
+            item_id: product.id,
+            item_name: product.nombre,
+            price: product.precio_base
+          }]
+        }
+      });
     }
   }, [product]);
 
@@ -141,6 +155,21 @@ function ProductDetailPage() {
       };
       window.fbq('track', 'AddToCart', itemData);
     }
+
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        event: 'add_to_cart',
+        ecommerce: {
+          currency: 'UYU',
+          value: precioFinalCalculado,
+          items: [{
+            item_id: product.id,
+            item_name: product.nombre,
+            price: precioUnitario,
+            quantity: quantity
+          }]
+        }
+      });
 
     const itemToAdd = {
       productId: product.id,


### PR DESCRIPTION
Añade los eventos view_item, add_to_cart, begin_checkout, purchase y generate_lead al dataLayer. Esto permite que Google Tag Manager capture las acciones clave del usuario para enviarlas a Google Analytics 4.

