### PR TITLE
Fix eliminación de huérfanos en Storage vía API con service role

### DIFF
--- a/api/admin-delete-storage-orphans.js
+++ b/api/admin-delete-storage-orphans.js
@@ -1,0 +1,66 @@
+import { createClient } from "@supabase/supabase-js";
+
+const BUCKET = "imagenes-productos";
+const BATCH_SIZE = 50;
+
+/**
+ * Elimina archivos del bucket usando service role (el cliente anon no tiene política DELETE).
+ *
+ * Variables en Vercel:
+ *   SUPABASE_URL, SUPABASE_SERVICE_KEY
+ *   ADMIN_SECRET_CODE — mismo valor que VITE_ADMIN_SECRET_CODE del frontend
+ */
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method Not Allowed" });
+  }
+
+  const adminSecret = process.env.ADMIN_SECRET_CODE;
+  if (!adminSecret) {
+    return res.status(500).json({
+      error:
+        "Falta ADMIN_SECRET_CODE en Vercel (mismo valor que VITE_ADMIN_SECRET_CODE).",
+    });
+  }
+
+  const { paths, adminCode } = req.body ?? {};
+  if (adminCode !== adminSecret) {
+    return res.status(401).json({ error: "No autorizado" });
+  }
+
+  if (!Array.isArray(paths) || paths.length === 0) {
+    return res.status(400).json({ error: "Se requiere un array paths con al menos un archivo." });
+  }
+
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_KEY;
+  if (!supabaseUrl || !serviceKey) {
+    return res.status(500).json({
+      error: "Faltan SUPABASE_URL o SUPABASE_SERVICE_KEY en Vercel.",
+    });
+  }
+
+  const supabase = createClient(supabaseUrl, serviceKey);
+  const deleted = [];
+  const errors = [];
+
+  for (let i = 0; i < paths.length; i += BATCH_SIZE) {
+    const batch = paths.slice(i, i + BATCH_SIZE);
+    const { error } = await supabase.storage.from(BUCKET).remove(batch);
+
+    if (error) {
+      errors.push(
+        `Lote ${Math.floor(i / BATCH_SIZE) + 1}: ${error.message}`,
+      );
+      continue;
+    }
+
+    deleted.push(...batch);
+  }
+
+  return res.status(200).json({
+    deletedCount: deleted.length,
+    failedCount: paths.length - deleted.length,
+    errors,
+  });
+}

--- a/src/pages/AdminPage/AdminPage.jsx
+++ b/src/pages/AdminPage/AdminPage.jsx
@@ -29,7 +29,7 @@ import {
 import { regenerateAllImageVariants } from "../../utils/regenerateImageVariants.js";
 import {
   auditStorageOrphans,
-  deleteStorageOrphans,
+  deleteStorageOrphansViaApi,
 } from "../../utils/storageAudit.js";
 import "./AdminPage.css";
 
@@ -963,10 +963,18 @@ const AdminPage = () => {
 
     try {
       const paths = storageAuditResult.orphans.map((f) => f.path);
-      const summary = await deleteStorageOrphans(supabase, paths, {
-        onProgress: setStorageAuditProgress,
-        isCancelled: () => storageAuditCancelRef.current,
-      });
+      const summary = await deleteStorageOrphansViaApi(
+        paths,
+        ADMIN_SECRET_CODE,
+      );
+
+      if (summary.deletedCount === 0 && paths.length > 0) {
+        toast.error(
+          summary.errors[0] ||
+            "No se pudo eliminar ningún archivo. Verificá ADMIN_SECRET_CODE y SUPABASE_SERVICE_KEY en Vercel.",
+        );
+        return;
+      }
 
       if (summary.failedCount > 0) {
         toast.warning(
@@ -2322,7 +2330,9 @@ const AdminPage = () => {
           <p className="admin-maintenance-intro">
             Detecta archivos en el bucket <code>imagenes-productos</code> que no
             están referenciados en productos ni telas. La carpeta{" "}
-            <code>hero/</code> (imágenes del sitio) queda protegida.
+            <code>hero/</code> (imágenes del sitio) queda protegida. La
+            eliminación se ejecuta en el servidor (requiere{" "}
+            <code>ADMIN_SECRET_CODE</code> en Vercel).
           </p>
 
           <div className="admin-maintenance-actions">

--- a/src/utils/storageAudit.js
+++ b/src/utils/storageAudit.js
@@ -171,44 +171,27 @@ export async function auditStorageOrphans(
   };
 }
 
-const DELETE_BATCH_SIZE = 50;
+/**
+ * Elimina huérfanos vía API serverless (service role). El cliente anon solo tiene
+ * SELECT/INSERT/UPDATE en Storage, no DELETE.
+ */
+export async function deleteStorageOrphansViaApi(paths, adminCode) {
+  const response = await fetch("/api/admin-delete-storage-orphans", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ paths, adminCode }),
+  });
 
-export async function deleteStorageOrphans(
-  supabase,
-  orphanPaths,
-  { onProgress, isCancelled } = {},
-) {
-  const deleted = [];
-  const errors = [];
+  const result = await response.json().catch(() => ({}));
 
-  for (let i = 0; i < orphanPaths.length; i += DELETE_BATCH_SIZE) {
-    if (isCancelled?.()) break;
-
-    const batch = orphanPaths.slice(i, i + DELETE_BATCH_SIZE);
-    onProgress?.({
-      current: Math.min(i + batch.length, orphanPaths.length),
-      total: orphanPaths.length,
-      label: `Eliminando ${batch.length} archivo(s)...`,
-    });
-
-    const { error } = await supabase.storage
-      .from(IMAGENES_BUCKET)
-      .remove(batch);
-
-    if (error) {
-      errors.push(
-        `Lote ${Math.floor(i / DELETE_BATCH_SIZE) + 1}: ${error.message}`,
-      );
-      continue;
-    }
-
-    deleted.push(...batch);
+  if (!response.ok) {
+    throw new Error(result.error || `Error al eliminar (${response.status})`);
   }
 
   return {
-    deletedCount: deleted.length,
-    failedCount: orphanPaths.length - deleted.length,
-    errors,
+    deletedCount: result.deletedCount ?? 0,
+    failedCount: result.failedCount ?? paths.length,
+    errors: Array.isArray(result.errors) ? result.errors : [],
   };
 }
 


### PR DESCRIPTION
El cliente anon no tiene política DELETE en el bucket; remove() no borraba archivos aunque el toast indicara éxito. Nueva ruta admin-delete-storage-orphans usa SUPABASE_SERVICE_KEY y valida ADMIN_SECRET_CODE en Vercel.